### PR TITLE
Proposal to send certificate chains in the clear

### DIFF
--- a/amp.asn1
+++ b/amp.asn1
@@ -45,7 +45,8 @@ DEFINITIONS ::= BEGIN
         payload                             [4]             AMPPDUPayload,
         -- all messages are signed by the sender. Devices from the Authority have their
         -- signatures verified at every hop.
-        signature                           [5] IMPLICIT    Signature
+	-- optional for certificate chain messages
+        signature                           [5] IMPLICIT    Signature OPTIONAL
     }
     
 -- ===================================================================
@@ -56,7 +57,8 @@ DEFINITIONS ::= BEGIN
 -- ===================================================================
     AMPPDUPayload ::= CHOICE {
         encryptedPayload                    [0] AMPEncryptedPDUPayload,
-        unencryptedPayload                  [1] UnencryptedAuthorityMessage
+        unencryptedPayload                  [1] UnencryptedAuthorityMessage,
+	certificateChain                    [2] CertificateChain
     }
 
     AMPEncryptedPDUPayload ::= SEQUENCE {


### PR DESCRIPTION
We have a chicken-and-egg problem in that we can only parse a message for which we can verify the signature, but we can only do that if we have the certificate chain leading up to whatever signed the message. If we don't have the identity certificate of the Authority that sent us a message, we can't parse any messages from that Authority, no matter how legitimate it may be. This change allows the Authority to send a certificate chain without signing the message, thus allowing a device to receive and validate the chain without first having the certificate to validate the message with